### PR TITLE
Add selective healthcheck api.

### DIFF
--- a/server/apps/distributed-app/pom.xml
+++ b/server/apps/distributed-app/pom.xml
@@ -465,7 +465,7 @@
                         </platforms>
                     </from>
                     <to>
-                        <image>shn27/inbox-server</image>
+                        <image>sami7786/inbox-server</image>
                         <tags>
                             <tag>distributed-latest</tag>
                         </tags>

--- a/server/apps/postgres-app/docker-compose-minimal.yml
+++ b/server/apps/postgres-app/docker-compose-minimal.yml
@@ -3,7 +3,7 @@ services:
     depends_on:
       postgres:
         condition: service_started
-    image: shn27/inbox-server:postgres-latest
+    image: sami7786/inbox-server:postgres-latest
     container_name: james
     hostname: james.local
     command:

--- a/server/apps/postgres-app/pom.xml
+++ b/server/apps/postgres-app/pom.xml
@@ -356,7 +356,7 @@
                         </platforms>
                     </from>
                     <to>
-                        <image>shn27/inbox-server</image>
+                        <image>sami7786/inbox-server</image>
                         <tags>
                             <tag>postgres-latest</tag>
                         </tags>

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/HealthCheckRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/HealthCheckRoutesTest.java
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.restassured.RestAssured;
 import net.javacrumbs.jsonunit.core.Option;
 import reactor.core.publisher.Mono;
@@ -78,7 +80,7 @@ class HealthCheckRoutesTest {
     @BeforeEach
     void setUp() throws Exception {
         healthChecks = new HashSet<>();
-        webAdminServer = WebAdminUtils.createWebAdminServer(new HealthCheckRoutes(healthChecks, new JsonTransformer()))
+        webAdminServer = WebAdminUtils.createWebAdminServer(new HealthCheckRoutes(healthChecks, new JsonTransformer(), new ObjectMapper()))
             .start();
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.spy;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.james.DefaultUserEntityValidator;
 import org.apache.james.RecipientRewriteTableUserEntityValidator;
 import org.apache.james.UserEntityValidator;

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.spy;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.james.DefaultUserEntityValidator;
 import org.apache.james.RecipientRewriteTableUserEntityValidator;
 import org.apache.james.UserEntityValidator;


### PR DESCRIPTION
Usage: Send a GET request to the webadmin http://host:port/healthcheck endpoint with the components names in the body as a json list. e.g; 
```bash
curl --location --request GET 'http://localhost:8000/healthcheck' \
--header 'Content-Type: application/json' \
--data '[
    "IMAPHealthCheck",
    "Postgres",
    "Embedded ActiveMQ"
]'
```
Example response:
```json
{
    "status": "healthy",
    "checks": [
        {
            "componentName": "Embedded ActiveMQ",
            "escapedComponentName": "Embedded%20ActiveMQ",
            "status": "healthy",
            "cause": null
        },
        {
            "componentName": "IMAPHealthCheck",
            "escapedComponentName": "IMAPHealthCheck",
            "status": "healthy",
            "cause": null
        },
        {
            "componentName": "Postgres",
            "escapedComponentName": "Postgres",
            "status": "healthy",
            "cause": null
        }
    ]
}
```